### PR TITLE
feat(schemaCreator components): array类型表单大调整；增加可选择的父元素类型-array及对应的新功能

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@
 
 ## Update Log
 
+### 2018-01-22
+
+- 调整array类型的表单构造schema方式，隐藏创建items和fixedItems(现在用不到)
+- 调整可选择的父元素，父元素可选择为array
+- 父元素设置为array时，可以选择将元素添加为fixedItems或items（视情况而定可能为additionalItems）
+
 ### 2018-01-21
 
 - 完善构造array类型的表单，完善重置schema和单部分表单的功能

--- a/src/routes/jsonschema/JsonSchema.js
+++ b/src/routes/jsonschema/JsonSchema.js
@@ -13,14 +13,11 @@ import ArraySchemaCreator from '@components/SchemaCreator/ArraySchemaCreator';
 
 // * antd组件
 import {
-  Button,
   Tabs,
-  Select,
   message
 } from 'antd';
 
 const TabPane = Tabs.TabPane;
-const Option = Select.Option;
 
 class JsonSchema extends React.Component {
 
@@ -32,7 +29,7 @@ class JsonSchema extends React.Component {
       description: 'outer-object-desc',
       required: [],
       properties: {
-        ts: {
+        tsobject: {
           type: 'object',
           title: 'test title',
           properties: {
@@ -41,6 +38,10 @@ class JsonSchema extends React.Component {
               title: 'dewq'
             }
           }
+        },
+        tsarray: {
+          type: 'array',
+          title: 'frehgie'
         }
       }
     },
@@ -50,6 +51,12 @@ class JsonSchema extends React.Component {
 
   componentDidMount () {
 
+  }
+
+  componentDidCatch () {
+    this.messageError({
+      message: '出现未知错误'
+    });
   }
 
   // * ------------
@@ -66,12 +73,33 @@ class JsonSchema extends React.Component {
         tmpProperties = tmpProperties[item];
       }
     }
-    if (tmpProperties && tmpProperties.properties) {
+    if (tmpProperties && tmpProperties.type === 'object' && tmpProperties.properties) {
       tmpProperties.properties[newProperty.key] = newProperty;
+    } else if (tmpProperties && tmpProperties.type === 'array' && newProperty.asFixedItems) {
+      delete newProperty.asFixedItems;
+      if (Object.prototype.toString.call(tmpProperties.items).indexOf('Object') !== -1) {
+        tmpProperties.additionalItems = tmpProperties.items;
+        tmpProperties.items = [];
+        tmpProperties.items.push(newProperty);
+      } else if (Object.prototype.toString.call(tmpProperties.items).indexOf('Array') !== -1) {
+        tmpProperties.items.push(newProperty);
+      } else {
+        tmpProperties.items = [];
+        tmpProperties.items.push(newProperty);
+      }
+    } else if (tmpProperties && tmpProperties.type === 'array' && newProperty.coverFixedItems) {
+      delete newProperty.coverFixedItems;
+      delete tmpProperties.additionalItems;
+      tmpProperties.items = newProperty;
+    } else if (tmpProperties && tmpProperties.type === 'array') {
+      if (Object.prototype.toString.call(tmpProperties.items).indexOf('Array') !== -1) {
+        tmpProperties.additionalItems = newProperty;
+      } else {
+        tmpProperties.items = newProperty;
+      }
     } else {
       tmpProperties[newProperty.key] = newProperty;
     }
-    console.log('useProperties', useProperties);
     this.setState((prevState, props) => {
       return {
         JSONSchema: {
@@ -79,7 +107,30 @@ class JsonSchema extends React.Component {
           properties: useProperties
         }
       }
+    }, () => {
+      this.messageSuccess({
+        message: '添加成功'
+      });
     });
+  }
+
+  // * ------------
+
+  messageSuccess = (param = {
+    message: '成功'
+  }) => {
+    message.success(param.message, () => {
+
+    });
+  }
+  messageError = () => {
+
+  }
+  messageWarning = () => {
+
+  }
+  messageInfo = () => {
+
   }
 
   // * ------------


### PR DESCRIPTION
调整array类型的表单构造schema方式，隐藏创建items和fixedItems(现在用不到)；调整可选择的父元素，父元素可选择为array；父元素设置为array时，可以选择将元素添加为fixedItems或items（视情况而定可能为additionalItems）