### PR TITLE
feat(JsonSchema-components): 新增功能；调整功能，修复已知问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,17 @@
   - Custom titles
   - Custom descriptions
 
-## Update Log
+## Change Log
+
+### 2018-01-31
+
+- array类型的schema构造器加入minItems设置
+- 使用minItems时，formData会根据default值判断是否需要填充空值
+- 完善HTML5 Input Types功能
+- 完善Custom labels for enum fields功能
+- 修复已知问题
+  - 根目录type为对象时，无法正确生成properties的uiSchema
+  - 根目录type为数组时，生成的formData成员重复
 
 ### 2018-01-30
 

--- a/src/components/FormCreator/PreviewForm.js
+++ b/src/components/FormCreator/PreviewForm.js
@@ -16,21 +16,7 @@ class PreviewForm extends React.Component {
     console.log('JSONSchema:', nextProps.JSONSchema);
     console.log('UISchema:', nextProps.UISchema);
     console.log('FormData:', nextProps.FormData);
-    let data = null;
-    if (nextProps.JSONSchema.type === 'object') {
-      data = {
-        ...nextProps.FormData
-      };
-    } else if (nextProps.JSONSchema.type === 'array') {
-      data = [
-        ...nextProps.FormData
-      ]
-    } else {
-      data = '';
-    }
-    this.setState({
-      FormData: data
-    });
+    this.prepareData(nextProps);
   }
 
   componentDidMount () {
@@ -38,14 +24,20 @@ class PreviewForm extends React.Component {
     console.log('JSONSchema:', this.props.JSONSchema);
     console.log('UISchema:', this.props.UISchema);
     console.log('FormData:', this.props.FormData);
+    this.prepareData(this.props);
+  }
+
+  // * ------------
+
+  prepareData = (props) => {
     let data = null;
-    if (this.props.JSONSchema.type === 'object') {
+    if (props.JSONSchema.type === 'object') {
       data = {
-        ...this.props.FormData
+        ...props.FormData
       };
-    } else if (this.props.JSONSchema.type === 'array') {
+    } else if (props.JSONSchema.type === 'array') {
       data = [
-        ...this.props.FormData
+        ...props.FormData
       ]
     } else {
       data = '';
@@ -62,7 +54,8 @@ class PreviewForm extends React.Component {
       <div className="borderbox padding-middle">
         <Form schema={ this.props.JSONSchema }
               uiSchema={ this.props.UISchema }
-              formData={ this.state.FormData }/>
+              formData={ this.state.FormData }
+              liveValidate={ true }/>
       </div>
     )
   }

--- a/src/components/SchemaCreator/ArraySchemaCreator.js
+++ b/src/components/SchemaCreator/ArraySchemaCreator.js
@@ -36,6 +36,7 @@ class ArraySchemaCreator extends React.Component {
     asFixedItems: false,
     coverFixedItems: false,
     refStatus: false,
+    useDefault: false,
     asDefinition: false,
     ownerList: [],
     defList: [],
@@ -54,6 +55,10 @@ class ArraySchemaCreator extends React.Component {
       owner: '',
       defOwner: 'definitions',
       $ref: ''
+    },
+    arraySchemaOptions: {
+      default: [],
+      minItems: ''
     },
     additionalItems: {},
     fixedItemsList: [],
@@ -321,6 +326,7 @@ class ArraySchemaCreator extends React.Component {
       asFixedItems: false,
       coverFixedItems: false,
       refStatus: false,
+      useDefault: false,
       asDefinition: false,
       uniqueItemsStatus: false,
       newDep: {
@@ -332,10 +338,13 @@ class ArraySchemaCreator extends React.Component {
         key: '',
         title: '',
         description: '',
-        default: [],
         owner: '',
         defOwner: 'definitions',
         $ref: ''
+      },
+      arraySchemaOptions: {
+        default: [],
+        minItems: ''
       },
       additionalItems: {},
       fixedItemsList: [],
@@ -375,6 +384,16 @@ class ArraySchemaCreator extends React.Component {
       data.asFixedItems = true;
     } else if (this.state.ownerTypeStatus === 'array' && this.state.coverFixedItems) {
       data.coverFixedItems = true;
+    }
+
+    // * 判断是否应该加入default
+    if (this.state.useDefault) {
+      data.default = this.state.arraySchemaOptions.default;
+    }
+
+    // * 判断是否应该加入minItems
+    if (this.state.arraySchemaOptions.minItems !== '') {
+      data.minItems = this.state.arraySchemaOptions.minItems;
     }
 
     // * 判断是否应该加入依赖
@@ -473,21 +492,40 @@ class ArraySchemaCreator extends React.Component {
     });
     this.setState((prevState, props) => {
       return {
-        arraySchema: {
-          ...prevState.arraySchema,
+        arraySchemaOptions: {
+          ...prevState.arraySchemaOptions,
           default: tmpValueList
         }
       };
     });
   }
 
-  uiChange = (value) => {
-    console.log('uiChange value:', value);
+  useDefaultChange = (event) => {
+    let checked = event.target.checked;
+    this.setState((prevState, props) => {
+      let data = {
+        ...prevState.arraySchemaOptions
+      };
+      if (!checked) {
+        data.default = [];
+      }
+      return {
+        arraySchemaOptions: data,
+        useDefault: checked
+      }
+    });
+  }
+
+  minItemsInput = (event) => {
+    let tmpValue = event.target.value;
+    if (isNaN(Number(tmpValue))) {
+      return;
+    }
     this.setState((prevState, props) => {
       return {
-        arraySchema: {
-          ...prevState.arraySchema,
-          ui: value
+        arraySchemaOptions: {
+          ...prevState.arraySchemaOptions,
+          minItems: tmpValue === '' ? '' : Number(tmpValue)
         }
       };
     });
@@ -837,12 +875,17 @@ class ArraySchemaCreator extends React.Component {
               <Input value={ this.state.arraySchema.description } onInput={ this.descriptionInput }></Input>
             </FormItem>
 
-            <FormItem label="default">
-              <TextArea value={ this.state.arraySchema.default.join(',') } onInput={ this.defaultInput }></TextArea>
-            </FormItem>
-
             <FormItem label="uniqueItems">
               <Checkbox checked={ this.state.uniqueItemsStatus } onChange={ this.uniqueItemsStatusChange }>成员唯一（成员只有一个）</Checkbox>
+            </FormItem>
+
+            <FormItem label="default">
+              <Checkbox checked={ this.state.useDefault !== undefined ? this.state.useDefault : false } onChange={ this.useDefaultChange }>使用default</Checkbox>
+              <TextArea disabled={ this.state.useDefault !== undefined ? !this.state.useDefault : false } value={ this.state.arraySchemaOptions.default !== undefined ? this.state.arraySchemaOptions.default.join(',') : '' } onInput={ this.defaultInput }></TextArea>
+            </FormItem>
+
+            <FormItem label="minItems">
+              <Input value={ this.state.arraySchemaOptions.minItems } onInput={ this.minItemsInput }></Input>
             </FormItem>
 
             <FormItem label="properties dependencies">

--- a/src/components/SchemaCreator/UICreator/ArrayUICreator.js
+++ b/src/components/SchemaCreator/UICreator/ArrayUICreator.js
@@ -113,7 +113,7 @@ class ArrayUICreator extends React.Component {
 
         <FormItem label="options">
 
-          <Checkbox checked={ this.state.uiOptions.orderable !== undefined ? this.state.uiOptions.orderable : false } onChange={ (event) => {
+          <Checkbox checked={ this.state.uiOptions.orderable !== undefined ? !this.state.uiOptions.orderable : false } onChange={ (event) => {
             this.uiOptionsChange({
               key: 'orderable',
               value: !(event.target.checked)
@@ -121,7 +121,7 @@ class ArrayUICreator extends React.Component {
           } }>
             禁止数组成员排序
           </Checkbox>
-          <Checkbox checked={ this.state.uiOptions.addable !== undefined ? this.state.uiOptions.addable : false } onChange={ (event) => {
+          <Checkbox checked={ this.state.uiOptions.addable !== undefined ? !this.state.uiOptions.addable : false } onChange={ (event) => {
             this.uiOptionsChange({
               key: 'addable',
               value: !(event.target.checked)
@@ -129,7 +129,7 @@ class ArrayUICreator extends React.Component {
           } }>
             禁止添加数组成员
           </Checkbox>
-          <Checkbox checked={ this.state.uiOptions.removeable !== undefined ? this.state.uiOptions.removeable : false } onChange={ (event) => {
+          <Checkbox checked={ this.state.uiOptions.removeable !== undefined ? !this.state.uiOptions.removeable : false } onChange={ (event) => {
             this.uiOptionsChange({
               key: 'removeable',
               value: !(event.target.checked)

--- a/src/utils/functions.js
+++ b/src/utils/functions.js
@@ -3,20 +3,19 @@ import { message } from 'antd';
 export default {
   I64BIT_TABLE: 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-'.split(''),
   createHash: (input) => {
-    var hash = 5381;
-    var i = input.length - 1;
+    let hash = 5381;
+    let i = input.length - 1;
 
-    if(typeof input === 'string'){
+    if (typeof input === 'string') {
       for (; i > -1; i--)
       hash += (hash << 5) + input.charCodeAt(i);
-    }
-    else{
+    } else {
       for (; i > -1; i--)
       hash += (hash << 5) + input[i];
     }
-    var value = hash & 0x7FFFFFFF;
+    let value = hash & 0x7FFFFFFF;
 
-    var retValue = '';
+    let retValue = '';
     do {
       retValue += this.I64BIT_TABLE[value & 0x3F];
     }
@@ -27,7 +26,7 @@ export default {
   createRandomId: () => {
     let str = '';
     let pos = null;
-    const arr = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z'];
+    const arr = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_'.split('');
     let range = Math.round(Math.random() * (6 - 4)) + 4;
     for (var i = 0; i < range; i++) {
       pos = Math.round(Math.random() * (arr.length - 1));


### PR DESCRIPTION
array类型的schema构造器加入minItems设置；使用minItems时，formData会根据default值判断是否需要填充空值；完善HTML5 Input Types功能；完善Custom labels for enum fields功能；修复已知问题：1.根目录type为对象时，无法正确生成properties的uiSchema；2.根目录type为数组时，生成的formData成员重复